### PR TITLE
Update-_types -- add bluesky as type for Social Media.

### DIFF
--- a/_data/types.yaml
+++ b/_data/types.yaml
@@ -104,6 +104,13 @@ twitter:
   tooltip: Twitter
   link: https://twitter.com/$VALUE
 
+# added by TG on 12.01.2025
+bluesky:
+  icon: fa-brands fa-bluesky
+  text: Bluesky
+  tooltip: Bluesky
+  link: https://bsky.app/profile/$VALUE.bsky.social 
+
 facebook:
   icon: fa-brands fa-facebook
   text: Facebook


### PR DESCRIPTION
#add bluesky as type for Social Media.

This website is based on the Lab Website Template.
See its documentation for working with this site:

https://greene-lab.gitbook.io/lab-website-template-docs
